### PR TITLE
Add hash option to support deterministic cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 Stamp for Craft
 ===========
 
-A tiny plugin for adding timestamp to filenames. 
+A tiny plugin for adding timestamp to filenames.
 
 
 Usage
 ---
 Use it like this:
- 
-    <script src="{{ craft.stamp.er('/assets/build/js/scripts.js') }}"></script> 
+
+    <script src="{{ craft.stamp.er('/assets/build/js/scripts.js') }}"></script>
 
 Which results in:
 
@@ -18,7 +18,7 @@ The er() method takes a second parameter for setting the format of the output. P
 
 Example with `folder`:
 
-    <script src="{{ craft.stamp.er('/assets/build/js/scripts.js', 'folder') }}"></script> 
+    <script src="{{ craft.stamp.er('/assets/build/js/scripts.js', 'folder') }}"></script>
 
 Result:
 
@@ -26,7 +26,7 @@ Result:
 
 Example with `query`:
 
-    <script src="{{ craft.stamp.er('/assets/build/js/scripts.js', 'query') }}"></script> 
+    <script src="{{ craft.stamp.er('/assets/build/js/scripts.js', 'query') }}"></script>
 
 Result:
 
@@ -34,13 +34,28 @@ Result:
 
 Example with `tsonly`:
 
-    Timestamp is: {{ craft.stamp.er('/assets/build/js/scripts.js', 'tsonly') }} 
+    Timestamp is: {{ craft.stamp.er('/assets/build/js/scripts.js', 'tsonly') }}
 
 Result:
 
     Timestamp is: 1399647655
 
 
+### Hashing option
+
+The er() method takes a third parameter for setting the algorithm of the output. Possible values are `ts` (default), and `hash`.
+
+`ts` stands for timestamp and behaves as shown above. `hash` gets the CRC32 checksum of the file instead of the timestamp. It's useful for cases when you need your cache busting to be fully deterministic.
+
+For example:
+
+    <script src="{{ craft.stamp.er('/assets/build/js/scripts.js', 'file', 'hash') }}"></script>
+
+Result:
+
+    <script src="/assets/build/js/scripts.2031312059.js"></script>
+
+Note: For the sake of consistency, calling `er('file', 'tsonly', 'hash')` will return just the hash, despite the fact that `tsonly` starts with `ts`.
 
 URL rewriting
 ---
@@ -59,7 +74,7 @@ nginx:
     location @assetversioning {
         rewrite ^(.+)\.[0-9]+\.(css|js)$ $1.$2 last;  # /assets/build/js/scripts.1399647655.js
         # rewrite ^(.+)/([0-9]+)/(.+)\.(js|css)$ $1/$3.$4 last;  # /assets/build/js/1399647655/scripts.js
-    }    
+    }
 
     location ~* ^/assets/.*\.(?:css|js)$ {
         try_files $uri @assetversioning;
@@ -72,10 +87,10 @@ nginx:
 Configuration
 ---
 Stamp needs to know the public document root to know where your files are located. By default
-Stamp will use $_SERVER['DOCUMENT_ROOT'], but on some server configurations this is not the correct 
-path. You can configure the path by setting the stampPublicRoot setting in your config file 
+Stamp will use $_SERVER['DOCUMENT_ROOT'], but on some server configurations this is not the correct
+path. You can configure the path by setting the stampPublicRoot setting in your config file
 (usually found in /craft/config/general.php)
- 
+
 ####Example
 
     'stampPublicRoot' => '/path/to/website/public/',
@@ -85,6 +100,6 @@ Changelog
 ---
 ### Version 1.1
  - Added additional parameter to output filepaths in different formats
- 
+
 ### Version 1.0
  - Initial release

--- a/StampPlugin.php
+++ b/StampPlugin.php
@@ -4,23 +4,23 @@ namespace Craft;
 
 class StampPlugin extends BasePlugin
 {
-	public function getName()
-	{
-		return Craft::t('Stamp');
-	}
+  public function getName()
+  {
+    return Craft::t('Stamp');
+  }
 
-	public function getVersion()
-	{
-		return '1.1';
-	}
+  public function getVersion()
+  {
+    return '1.1';
+  }
 
-	public function getDeveloper()
-	{
-		return 'André Elvan';
-	}
+  public function getDeveloper()
+  {
+    return 'André Elvan';
+  }
 
-	public function getDeveloperUrl()
-	{
-		return 'http://vaersaagod.no';
-	}
+  public function getDeveloperUrl()
+  {
+    return 'http://vaersaagod.no';
+  }
 }

--- a/services/StampService.php
+++ b/services/StampService.php
@@ -3,34 +3,32 @@ namespace Craft;
 
 class StampService extends BaseApplicationComponent
 {
-  
+
   var $settings = array();
-  
-	/**
-	 * Gets a plugin setting
-   * 
-	 * @param $name String Setting name
-	 * @return mixed Setting value
-	 * @author André Elvan
-	*/
+
+  /**
+   * Gets a plugin setting
+   *
+   * @param $name String Setting name
+   * @return mixed Setting value
+   * @author André Elvan
+  */
   public function getSetting($name) {
     $this->settings = $this->_init_settings();
     return $this->settings[$name];
   }
-  
 
-	/**
-	 * Gets Stamp settings from config
-   * 
-	 * @return array Array containing all settings
-	 * @author André Elvan
-	*/
+  /**
+   * Gets Stamp settings from config
+   *
+   * @return array Array containing all settings
+   * @author André Elvan
+  */
   private function _init_settings() {
     $settings = array();
     $settings['stampPublicRoot'] = craft()->config->get('stampPublicRoot');
-    
+
     return $settings;
   }
-  
-  
+
 }

--- a/variables/StampVariable.php
+++ b/variables/StampVariable.php
@@ -3,25 +3,25 @@ namespace Craft;
 
 class StampVariable
 {
-	public function er($fileName, $mode='file')
-	{
+  public function er($fileName, $mode='file')
+  {
     $documentRoot = craft()->stamp->getSetting('stampPublicRoot')!=null ? craft()->stamp->getSetting('stampPublicRoot') : $_SERVER['DOCUMENT_ROOT'];
     $filePath = $documentRoot . $fileName;
-    
+
     if ($fileName != '' && file_exists($filePath)) {
       $path_parts = pathinfo($fileName);
-      
-			if ($mode=='file') {
-				return $path_parts['dirname'] . '/' . $path_parts['filename'] . '.' . filemtime($filePath) . '.' . $path_parts['extension'];
-			} else if ($mode=='folder') {
-				return $path_parts['dirname'] . '/' . filemtime($filePath) . '/' . $path_parts['filename'] . '.' . $path_parts['extension'];
-			} else if ($mode=='query') {
-				return $path_parts['dirname'] . '/' . $path_parts['filename'] . '.' . $path_parts['extension'] . '?ts=' . filemtime($filePath);
-			} else if ($mode=='tsonly') {
-				return filemtime($filePath);
-			}
+
+      if ($mode=='file') {
+        return $path_parts['dirname'] . '/' . $path_parts['filename'] . '.' . filemtime($filePath) . '.' . $path_parts['extension'];
+      } else if ($mode=='folder') {
+        return $path_parts['dirname'] . '/' . filemtime($filePath) . '/' . $path_parts['filename'] . '.' . $path_parts['extension'];
+      } else if ($mode=='query') {
+        return $path_parts['dirname'] . '/' . $path_parts['filename'] . '.' . $path_parts['extension'] . '?ts=' . filemtime($filePath);
+      } else if ($mode=='tsonly') {
+        return filemtime($filePath);
+      }
     } else {
       return '';
     }
-	}
+  }
 }

--- a/variables/StampVariable.php
+++ b/variables/StampVariable.php
@@ -3,7 +3,16 @@ namespace Craft;
 
 class StampVariable
 {
-  public function er($fileName, $mode='file')
+  /**
+   * Exactly like hash_file except that the result is always numeric
+   * (consisting of characters 0-9 only).
+   */
+  public function num_hash_file($filePath)
+  {
+    return implode(unpack('C*', hash_file('crc32b', $filePath, true)));
+  }
+
+  public function er($fileName, $mode='file', $alg='ts')
   {
     $documentRoot = craft()->stamp->getSetting('stampPublicRoot')!=null ? craft()->stamp->getSetting('stampPublicRoot') : $_SERVER['DOCUMENT_ROOT'];
     $filePath = $documentRoot . $fileName;
@@ -11,14 +20,16 @@ class StampVariable
     if ($fileName != '' && file_exists($filePath)) {
       $path_parts = pathinfo($fileName);
 
+      $stamp = $alg === 'hash' ? $this->num_hash_file($filePath) : filemtime($filePath);
+
       if ($mode=='file') {
-        return $path_parts['dirname'] . '/' . $path_parts['filename'] . '.' . filemtime($filePath) . '.' . $path_parts['extension'];
+        return $path_parts['dirname'] . '/' . $path_parts['filename'] . '.' . $stamp . '.' . $path_parts['extension'];
       } else if ($mode=='folder') {
-        return $path_parts['dirname'] . '/' . filemtime($filePath) . '/' . $path_parts['filename'] . '.' . $path_parts['extension'];
+        return $path_parts['dirname'] . '/' . $stamp . '/' . $path_parts['filename'] . '.' . $path_parts['extension'];
       } else if ($mode=='query') {
-        return $path_parts['dirname'] . '/' . $path_parts['filename'] . '.' . $path_parts['extension'] . '?ts=' . filemtime($filePath);
+        return $path_parts['dirname'] . '/' . $path_parts['filename'] . '.' . $path_parts['extension'] . '?ts=' . $stamp;
       } else if ($mode=='tsonly') {
-        return filemtime($filePath);
+        return $stamp;
       }
     } else {
       return '';


### PR DESCRIPTION
Some deployment systems mess with the modified times of files. This addition allows users to fall back on a purely deterministic solution to cache busting.

I took the "liberty" of making your indentation consistent. If I did it wrong or if you prefer that I take it out, I will happily change it.